### PR TITLE
CT-1393: resize video preview after changing the layout

### DIFF
--- a/ios/RNRecorder.m
+++ b/ios/RNRecorder.m
@@ -296,6 +296,7 @@
    
    if (_previewView == nil) {
       _previewView = [[UIView alloc] initWithFrame:self.bounds];
+      _previewView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
       _recorder.previewView = _previewView;
       [_previewView setBackgroundColor:[UIColor blackColor]];
       [self insertSubview:_previewView atIndex:0];
@@ -305,7 +306,8 @@
       [self setVideoFormat:_videoFormat];
       _recorder.session = _session;
    }
-   
+   [_recorder previewViewFrameChanged];
+
    return;
 }
 


### PR DESCRIPTION
This solves the practice recorder resize bug, also the current extra `<View>` here https://github.com/CommercialTribe/mobile/blob/DEVELOPMENT/app/Components/Video/VideoRecorder.js#L216-L220, and future landscape resizing too